### PR TITLE
Fix Flow Scanner session handling

### DIFF
--- a/addon/button.js
+++ b/addon/button.js
@@ -138,24 +138,20 @@ function initButton(sfHost, inInspector) {
     const urlParams = new URLSearchParams(currentUrl.split('?')[1] || '');
     const flowDefId = urlParams.get('flowDefId');
     const flowId = urlParams.get('flowId');
-    
+
     if (!flowDefId || !flowId) {
       alert('Unable to detect flow information. Please make sure you are on a flow builder page.');
       return;
     }
-    
-    // Open flow scanner in a new window
-    const flowScannerUrl = chrome.runtime.getURL(`flow-scanner.html?flowDefId=${flowDefId}&flowId=${flowId}`);
-    const width = 800;
-    const height = 600;
-    const left = (screen.width - width) / 2;
-    const top = (screen.height - height) / 2;
-    
-    window.open(
-      flowScannerUrl,
-      'flow-scanner',
-      `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes,status=yes`
-    );
+
+    const args = new URLSearchParams();
+    args.set('host', sfHost);
+    args.set('flowDefId', flowDefId);
+    args.set('flowId', flowId);
+    const flowScannerUrl = chrome.runtime.getURL(`flow-scanner.html?${args}`);
+
+    const target = localStorage.getItem('openLinksInNewTab') === 'true' ? '_blank' : '_top';
+    window.open(flowScannerUrl, target);
   }
 
   // Calulates default position, left to right for horizontal, and adds boundaries to keep it on screen

--- a/addon/flow-scanner.html
+++ b/addon/flow-scanner.html
@@ -51,6 +51,7 @@
   
   <!-- Include Flow Scanner Core -->
   <script src="flow-scanner-core.js"></script>
-  <script src="flow-scanner.js"></script>
+  <script src="button.js"></script>
+  <script type="module" src="flow-scanner.js"></script>
 </body>
 </html> 

--- a/addon/flow-scanner.js
+++ b/addon/flow-scanner.js
@@ -1,6 +1,12 @@
 // Flow Scanner for Salesforce Inspector
+import {sfConn, apiVersion} from "./inspector.js";
+/* global initButton */
+
 class FlowScanner {
-  constructor() {
+  constructor(sfHost, flowDefId, flowId) {
+    this.sfHost = sfHost;
+    this.flowDefId = flowDefId;
+    this.flowId = flowId;
     this.currentFlow = null;
     this.scanResults = [];
     this.flowScannerCore = null;
@@ -35,18 +41,13 @@ class FlowScanner {
 
   async loadFlowInfo() {
     try {
-      // Get flow information from URL parameters
-      const urlParams = new URLSearchParams(window.location.search);
-      const flowDefId = urlParams.get('flowDefId');
-      const flowId = urlParams.get('flowId');
-
-      if (!flowDefId || !flowId) {
+      if (!this.flowDefId || !this.flowId) {
         this.showError('No flow information found in URL');
         return;
       }
 
       // Get flow metadata from Salesforce
-      const flowInfo = await this.getFlowMetadata(flowDefId, flowId);
+      const flowInfo = await this.getFlowMetadata(this.flowDefId, this.flowId);
       this.currentFlow = flowInfo;
       this.displayFlowInfo(flowInfo);
     } catch (error) {
@@ -57,25 +58,22 @@ class FlowScanner {
 
   async getFlowMetadata(flowDefId, flowId) {
     try {
-      // Try to get flow metadata from the parent window (Salesforce page)
-      const flowName = this.extractFlowNameFromPage();
-      const flowType = this.extractFlowTypeFromPage();
-      const flowStatus = this.extractFlowStatusFromPage();
-
-      // Get flow XML data
-      const xmlData = await this.getFlowXML(flowId);
+      const res = await sfConn.rest(
+        `/services/data/v${apiVersion}/tooling/sobjects/Flow/${flowId}`,
+        {method: 'GET'}
+      );
 
       return {
         id: flowId,
         definitionId: flowDefId,
-        name: flowName || 'Unknown Flow',
-        type: flowType || 'Unknown',
-        status: flowStatus || 'Unknown',
-        xmlData: xmlData
+        name:
+          res.FullName || res.MasterLabel || this.extractFlowNameFromPage(),
+        type: res.ProcessType || this.extractFlowTypeFromPage(),
+        status: res.Status || this.extractFlowStatusFromPage(),
+        xmlData: res.Metadata
       };
     } catch (error) {
       console.error('Error getting flow metadata:', error);
-      // Fallback to basic info
       return {
         id: flowId,
         definitionId: flowDefId,
@@ -125,65 +123,17 @@ class FlowScanner {
 
   async getFlowXML(flowId) {
     try {
-      // Try to get sfHost from the opener or parent window URL
-      let sfHost = null;
-      try {
-        const openerUrl = (window.opener && window.opener.location && window.opener.location.hostname) ? window.opener.location.hostname : null;
-        const parentUrl = (window.parent && window.parent.location && window.parent.location.hostname) ? window.parent.location.hostname : null;
-        sfHost = openerUrl || parentUrl;
-      } catch (e) {}
-      // If not found, try to parse from URL params
-      if (!sfHost) {
-        const urlParams = new URLSearchParams(window.location.search);
-        sfHost = urlParams.get('sfHost');
-      }
-      if (!sfHost) {
-        // Try to guess from the current tab's referrer
-        sfHost = document.referrer ? (new URL(document.referrer)).hostname : null;
-      }
-      if (!sfHost) {
-        throw new Error('Unable to determine Salesforce host');
-      }
-      // Use background script to fetch metadata
-      return await new Promise((resolve, reject) => {
-        chrome.runtime.sendMessage({
-          message: 'fetchFlowMetadata',
-          sfHost,
-          flowId
-        }, (response) => {
-          if (chrome.runtime.lastError) {
-            reject(new Error(chrome.runtime.lastError.message));
-            return;
-          }
-          if (response && response.data && response.data.Metadata) {
-            resolve(response.data.Metadata);
-          } else {
-            reject(new Error(response && response.error ? response.error : 'No metadata returned'));
-          }
-        });
-      });
+      const res = await sfConn.rest(
+        `/services/data/v${apiVersion}/tooling/sobjects/Flow/${flowId}`,
+        {method: 'GET'}
+      );
+      return res.Metadata;
     } catch (error) {
-      console.error('Error fetching flow XML via background:', error);
-      // Fallback: return basic flow data
+      console.error('Error fetching flow XML:', error);
       return this.extractFlowXMLFromPage();
     }
   }
 
-  getSessionId() {
-    // Get session ID from Salesforce page
-    const sessionId = this.getCookie('sid') || this.getCookie('sid_oauth');
-    if (!sessionId) {
-      throw new Error('No session ID found');
-    }
-    return sessionId;
-  }
-
-  getCookie(name) {
-    const value = `; ${document.cookie}`;
-    const parts = value.split(`; ${name}=`);
-    if (parts.length === 2) return parts.pop().split(';').shift();
-    return null;
-  }
 
   extractFlowXMLFromPage() {
     // Fallback method to extract flow data from page
@@ -411,8 +361,14 @@ class FlowScanner {
 }
 
 // Initialize the flow scanner when the page loads
-document.addEventListener('DOMContentLoaded', () => {
-  new FlowScanner();
+document.addEventListener('DOMContentLoaded', async () => {
+  const args = new URLSearchParams(window.location.search);
+  const sfHost = args.get('host');
+  const flowDefId = args.get('flowDefId');
+  const flowId = args.get('flowId');
+  initButton(sfHost, true);
+  await sfConn.getSession(sfHost);
+  new FlowScanner(sfHost, flowDefId, flowId);
 });
 
 // Listen for messages from the parent window

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1935,27 +1935,18 @@ class AllDataSelection extends React.PureComponent {
           ? h("a", {href: this.redirectToFlowVersions(), target: linkTarget, className: "button page-button slds-button slds-button_neutral slds-m-top_xx-small slds-m-bottom_xx-small"}, "Flow Versions") : null,
         // Flow Scanner button
         (flowDefinitionId && selectedValue.recordId)
-          ? h("a", {
-              href: "#",
-              className: "button page-button slds-button slds-button_neutral slds-m-top_xx-small slds-m-bottom_xx-small",
-              onClick: (e) => {
-                e.preventDefault();
-                const url = chrome.runtime.getURL(
-                  `flow-scanner.html?flowDefId=${flowDefinitionId}&flowId=${selectedValue.recordId}`
-                );
-                const width = 800;
-                const height = 600;
-                const left = (window.screen.width - width) / 2;
-                const top = (window.screen.height - height) / 2;
-                window.open(
-                  url,
-                  'flow-scanner',
-                  `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes,status=yes`
-                );
-              }
-            },
-            "Flow Scanner"
-          ) : null,
+          ? h(
+              "a",
+              {
+                href: chrome.runtime.getURL(
+                  `flow-scanner.html?host=${sfHost}&flowDefId=${flowDefinitionId}&flowId=${selectedValue.recordId}`
+                ),
+                target: linkTarget,
+                className: "button page-button slds-button slds-button_neutral slds-m-top_xx-small slds-m-bottom_xx-small"
+              },
+              "Flow Scanner"
+            )
+          : null,
         buttons.map((button, index) => h("div", {key: button + "Div"}, h("a",
           {
             key: button,


### PR DESCRIPTION
## Summary
- open Flow Scanner links with host parameter
- load Flow Scanner page like other tools
- fetch flow metadata via `sfConn` rather than background proxy

## Testing
- `npm run eslint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_685c5a2f57f483319eb4a45bf1146e35