### PR TITLE
Improve Flow Scanner integration

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -54,28 +54,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
       chrome.tabs.reload(tabs[0].id);
     });
-  } else if (request.message == "fetchFlowMetadata") {
-    // Proxy Tooling API call to Salesforce
-    const { sfHost, flowId } = request;
-    chrome.cookies.get({ url: "https://" + sfHost, name: "sid", storeId: sender.tab?.cookieStoreId }, sessionCookie => {
-      if (!sessionCookie) {
-        sendResponse({ error: "No session cookie found" });
-        return;
-      }
-      const sessionId = sessionCookie.value;
-      fetch(`https://${sfHost}/services/data/v58.0/tooling/sobjects/Flow/${flowId}`, {
-        method: "GET",
-        headers: {
-          "Authorization": `Bearer ${sessionId}`,
-          "Content-Type": "application/json"
-        },
-        credentials: "include"
-      })
-        .then(resp => resp.json())
-        .then(data => sendResponse({ data }))
-        .catch(err => sendResponse({ error: err.message }));
-    });
-    return true;
   }
   return false;
 });

--- a/addon/button.js
+++ b/addon/button.js
@@ -134,28 +134,57 @@ function initButton(sfHost, inInspector) {
   }
 
   function openFlowScanner(currentUrl) {
-    // Extract flow information from URL
-    const urlParams = new URLSearchParams(currentUrl.split('?')[1] || '');
-    const flowDefId = urlParams.get('flowDefId');
-    const flowId = urlParams.get('flowId');
-    
+    const url = new URL(currentUrl);
+    const urlParams = new URLSearchParams(url.search || "");
+    const flowDefId = urlParams.get("flowDefId");
+    const flowId = urlParams.get("flowId");
     if (!flowDefId || !flowId) {
-      alert('Unable to detect flow information. Please make sure you are on a flow builder page.');
+      alert("Unable to detect flow information. Please make sure you are on a flow builder page.");
       return;
     }
-    
-    // Open flow scanner in a new window
-    const flowScannerUrl = chrome.runtime.getURL(`flow-scanner.html?flowDefId=${flowDefId}&flowId=${flowId}`);
-    const width = 800;
-    const height = 600;
-    const left = (screen.width - width) / 2;
-    const top = (screen.height - height) / 2;
-    
-    window.open(
-      flowScannerUrl,
-      'flow-scanner',
-      `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes,status=yes`
-    );
+    openFlowScannerOverlay(url.hostname, flowDefId, flowId);
+  }
+
+  function openFlowScannerOverlay(sfHost, flowDefId, flowId) {
+    const overlayId = "flow-scanner-overlay";
+    let overlay = document.getElementById(overlayId);
+    if (!overlay) {
+      overlay = document.createElement("div");
+      overlay.id = overlayId;
+      Object.assign(overlay.style, {
+        position: "fixed",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        background: "rgba(0,0,0,0.6)",
+        zIndex: 10000,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center"
+      });
+      const iframeEl = document.createElement("iframe");
+      Object.assign(iframeEl.style, {
+        width: "80%",
+        height: "90%",
+        border: "none",
+        borderRadius: "8px",
+        background: "#fff"
+      });
+      overlay.appendChild(iframeEl);
+      overlay.addEventListener("click", e => {
+        if (e.target === overlay) overlay.remove();
+      });
+      addEventListener("keydown", function esc(e) {
+        if (e.key === "Escape") {
+          overlay.remove();
+          removeEventListener("keydown", esc);
+        }
+      });
+      document.body.appendChild(overlay);
+    }
+    const iframeEl = overlay.querySelector("iframe");
+    iframeEl.src = chrome.runtime.getURL(`flow-scanner.html?host=${sfHost}&flowDefId=${flowDefId}&flowId=${flowId}`);
   }
 
   // Calulates default position, left to right for horizontal, and adds boundaries to keep it on screen
@@ -352,6 +381,9 @@ function initButton(sfHost, inInspector) {
       }
       if (e.data.lightningNavigate) {
         document.dispatchEvent(new CustomEvent("lightningNavigate", {detail: e.data.lightningNavigate}));
+      }
+      if (e.data.openFlowScanner) {
+        openFlowScannerOverlay(sfHost, e.data.flowDefId, e.data.flowId);
       }
     });
     rootEl.appendChild(popupEl);

--- a/addon/flow-scanner.html
+++ b/addon/flow-scanner.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Flow Scanner</title>
+  <link rel="stylesheet" href="button.css">
   <link rel="stylesheet" href="flow-scanner.css">
 </head>
 <body>
@@ -50,7 +51,8 @@
   </div>
   
   <!-- Include Flow Scanner Core -->
+  <script src="button.js"></script>
   <script src="flow-scanner-core.js"></script>
-  <script src="flow-scanner.js"></script>
+  <script type="module" src="flow-scanner.js"></script>
 </body>
 </html> 

--- a/addon/flow-scanner.js
+++ b/addon/flow-scanner.js
@@ -1,6 +1,11 @@
 // Flow Scanner for Salesforce Inspector
+import {sfConn, apiVersion} from "./inspector.js";
+
 class FlowScanner {
-  constructor() {
+  constructor({sfHost, flowDefId, flowId}) {
+    this.sfHost = sfHost;
+    this.flowDefId = flowDefId;
+    this.flowId = flowId;
     this.currentFlow = null;
     this.scanResults = [];
     this.flowScannerCore = null;
@@ -35,18 +40,13 @@ class FlowScanner {
 
   async loadFlowInfo() {
     try {
-      // Get flow information from URL parameters
-      const urlParams = new URLSearchParams(window.location.search);
-      const flowDefId = urlParams.get('flowDefId');
-      const flowId = urlParams.get('flowId');
-
-      if (!flowDefId || !flowId) {
-        this.showError('No flow information found in URL');
+      if (!this.flowDefId || !this.flowId) {
+        this.showError('No flow information found');
         return;
       }
 
       // Get flow metadata from Salesforce
-      const flowInfo = await this.getFlowMetadata(flowDefId, flowId);
+      const flowInfo = await this.getFlowMetadata(this.flowDefId, this.flowId);
       this.currentFlow = flowInfo;
       this.displayFlowInfo(flowInfo);
     } catch (error) {
@@ -125,65 +125,14 @@ class FlowScanner {
 
   async getFlowXML(flowId) {
     try {
-      // Try to get sfHost from the opener or parent window URL
-      let sfHost = null;
-      try {
-        const openerUrl = (window.opener && window.opener.location && window.opener.location.hostname) ? window.opener.location.hostname : null;
-        const parentUrl = (window.parent && window.parent.location && window.parent.location.hostname) ? window.parent.location.hostname : null;
-        sfHost = openerUrl || parentUrl;
-      } catch (e) {}
-      // If not found, try to parse from URL params
-      if (!sfHost) {
-        const urlParams = new URLSearchParams(window.location.search);
-        sfHost = urlParams.get('sfHost');
-      }
-      if (!sfHost) {
-        // Try to guess from the current tab's referrer
-        sfHost = document.referrer ? (new URL(document.referrer)).hostname : null;
-      }
-      if (!sfHost) {
-        throw new Error('Unable to determine Salesforce host');
-      }
-      // Use background script to fetch metadata
-      return await new Promise((resolve, reject) => {
-        chrome.runtime.sendMessage({
-          message: 'fetchFlowMetadata',
-          sfHost,
-          flowId
-        }, (response) => {
-          if (chrome.runtime.lastError) {
-            reject(new Error(chrome.runtime.lastError.message));
-            return;
-          }
-          if (response && response.data && response.data.Metadata) {
-            resolve(response.data.Metadata);
-          } else {
-            reject(new Error(response && response.error ? response.error : 'No metadata returned'));
-          }
-        });
-      });
+      const result = await sfConn.rest(`/services/data/v${apiVersion}/tooling/sobjects/Flow/${flowId}`);
+      return result.Metadata;
     } catch (error) {
-      console.error('Error fetching flow XML via background:', error);
-      // Fallback: return basic flow data
+      console.error('Error fetching flow XML:', error);
       return this.extractFlowXMLFromPage();
     }
   }
 
-  getSessionId() {
-    // Get session ID from Salesforce page
-    const sessionId = this.getCookie('sid') || this.getCookie('sid_oauth');
-    if (!sessionId) {
-      throw new Error('No session ID found');
-    }
-    return sessionId;
-  }
-
-  getCookie(name) {
-    const value = `; ${document.cookie}`;
-    const parts = value.split(`; ${name}=`);
-    if (parts.length === 2) return parts.pop().split(';').shift();
-    return null;
-  }
 
   extractFlowXMLFromPage() {
     // Fallback method to extract flow data from page
@@ -412,7 +361,14 @@ class FlowScanner {
 
 // Initialize the flow scanner when the page loads
 document.addEventListener('DOMContentLoaded', () => {
-  new FlowScanner();
+  const params = new URLSearchParams(location.search.slice(1));
+  const sfHost = params.get('host');
+  const flowDefId = params.get('flowDefId');
+  const flowId = params.get('flowId');
+  initButton(sfHost, true);
+  sfConn.getSession(sfHost).then(() => {
+    new FlowScanner({sfHost, flowDefId, flowId});
+  });
 });
 
 // Listen for messages from the parent window

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1940,18 +1940,11 @@ class AllDataSelection extends React.PureComponent {
               className: "button page-button slds-button slds-button_neutral slds-m-top_xx-small slds-m-bottom_xx-small",
               onClick: (e) => {
                 e.preventDefault();
-                const url = chrome.runtime.getURL(
-                  `flow-scanner.html?flowDefId=${flowDefinitionId}&flowId=${selectedValue.recordId}`
-                );
-                const width = 800;
-                const height = 600;
-                const left = (window.screen.width - width) / 2;
-                const top = (window.screen.height - height) / 2;
-                window.open(
-                  url,
-                  'flow-scanner',
-                  `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes,status=yes`
-                );
+                parent.postMessage({
+                  openFlowScanner: true,
+                  flowDefId: flowDefinitionId,
+                  flowId: selectedValue.recordId
+                }, "*");
               }
             },
             "Flow Scanner"


### PR DESCRIPTION
## Summary
- open the Flow Scanner in-page instead of a new window
- expose overlay opener so the popup can request it
- fetch Flow metadata through `sfConn.rest`
- load extension CSS/JS resources for the scanner page
- drop unused background logic

## Testing
- `npm run eslint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a2f57f483319eb4a45bf1146e35