### PR TITLE
Enable rule selection for Flow Scanner

### DIFF
--- a/addon/flow-scanner.js
+++ b/addon/flow-scanner.js
@@ -525,7 +525,24 @@ class FlowScanner {
 
       // Use the scan method from Flow Scanner Core with ParsedFlow array
       console.log("Calling flowScannerCore.scan with parsed flow");
-      const scanResults = this.flowScannerCore.scan([parsedFlow]);
+      let ruleConfig;
+      try {
+        const stored = JSON.parse(localStorage.getItem("flowScannerRules") || "[]");
+        const selected = stored.filter(c => c.checked).map(c => c.name);
+        if (selected.length) {
+          const allRules = this.flowScannerCore.getRules().map(r => r.name);
+          const disabled = allRules.filter(name => !selected.includes(name));
+          if (disabled.length) {
+            ruleConfig = {rules: {}};
+            disabled.forEach(name => {
+              ruleConfig.rules[name] = {disabled: "true"};
+            });
+          }
+        }
+      } catch (e) {
+        console.error("Error preparing rule configuration", e);
+      }
+      const scanResults = this.flowScannerCore.scan([parsedFlow], ruleConfig);
       console.log("Flow Scanner Core returned results:", scanResults);
       console.log("Scan results type:", typeof scanResults);
       console.log("Scan results length:", scanResults?.length);

--- a/addon/options.html
+++ b/addon/options.html
@@ -12,6 +12,7 @@
     <script src="react.js"></script>
     <script src="react-dom.js"></script>
     <script src="button.js"></script>
+    <script src="flow-scanner-core.js"></script>
     <script type="module" src="options.js"></script>
   </body>
 </html>

--- a/addon/options.js
+++ b/addon/options.js
@@ -74,6 +74,12 @@ class OptionsTabSelector extends React.Component {
       selectedTabId: initialTabId
     };
 
+    const ruleCheckboxes = (window.lightningflowscanner?.getRules() || []).map((rule) => ({
+      label: rule.label || rule.name,
+      name: rule.name,
+      checked: true
+    }));
+
     this.tabs = [
       {
         id: 1,
@@ -213,7 +219,18 @@ class OptionsTabSelector extends React.Component {
               ]
             }
           },
-          {option: Option, props: {type: "toggle", title: "Use legacy version", key: "useLegacyDlMetadata", default: false}},
+      {option: Option, props: {type: "toggle", title: "Use legacy version", key: "useLegacyDlMetadata", default: false}},
+        ]
+      },
+      {
+        id: 8,
+        tabTitle: "Tab7",
+        title: "Flow Scanner",
+        content: [
+          {option: MultiCheckboxButtonGroup,
+            props: {title: "Enabled Rules",
+              key: "flowScannerRules",
+              checkboxes: ruleCheckboxes}}
         ]
       }
     ];


### PR DESCRIPTION
## Summary
- load Flow Scanner Core on the options page
- generate rule checkboxes from `getRules()`
- add Flow Scanner settings tab with rule selection
- disable unselected rules when scanning flows

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d80a11b7c8331818726863a1e395d