### PR TITLE
Add configurable naming convention rule for Flow Scanner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 - Add new domain for Visualforce pages cf [Ensure Access to Your Visualforce Pages in Summer ’24 and Winter ’25](https://help.salesforce.com/s/articleView?id=001406148&type=1)
 - Security improvements thanks to [Rikaard Hosein](https://github.com/rikaardhosein) [fix 661](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/661)
 - Add option for `Field Creator` to allow users to choose between PascalCase and Underscores for new field API names. [feature 655](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/655) (contribution by [Steve Quirion](https://github.com/sqone2))
+- Add configuration option to set the Flow Scanner naming convention regex.
 - Customize Data Export shortcuts (execute query and insert all fields name in query) [feature 653](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/653) in `chrome://extensions/shortcuts`
 - Add [clientId](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers_calloptions.htm) header param to identify the extension in EventLogFile [feature 504](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/504)
 - Add Apex Classes metadata search in Shortcut tab and new option configuration for the search [feature 591](https://github.com/tprouvot/Salesforce-Inspector-reloaded/issues/591) request by [mpekacki](https://github.com/mpekacki)

--- a/addon/flow-scanner.js
+++ b/addon/flow-scanner.js
@@ -539,6 +539,12 @@ class FlowScanner {
             });
           }
         }
+        const namingRegex = localStorage.getItem("flowScannerNamingRegex");
+        if (namingRegex) {
+          if (!ruleConfig) ruleConfig = {rules: {}};
+          if (!ruleConfig.rules) ruleConfig.rules = {};
+          ruleConfig.rules.FlowName = {expression: namingRegex};
+        }
       } catch (e) {
         console.error("Error preparing rule configuration", e);
       }

--- a/addon/options.js
+++ b/addon/options.js
@@ -230,7 +230,9 @@ class OptionsTabSelector extends React.Component {
           {option: MultiCheckboxButtonGroup,
             props: {title: "Enabled Rules",
               key: "flowScannerRules",
-              checkboxes: ruleCheckboxes}}
+              checkboxes: ruleCheckboxes}},
+          {option: Option,
+            props: {type: "text", title: "Flow Naming Convention Regex", key: "flowScannerNamingRegex", default: "[A-Za-z0-9]+_[A-Za-z0-9]+", tooltip: "Regular expression applied by the Flow Naming Convention rule"}}
         ]
       }
     ];


### PR DESCRIPTION
## Summary
- add Flow Scanner naming convention setting in options page
- apply regex setting when running Flow Scanner
- document new option in release notes

## Testing
- `npm run eslint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_685d85b493f88331bd2f135c3afe7fcc