### PR TITLE
Fix flow scanner rule config parsing

### DIFF
--- a/addon/flow-scanner.js
+++ b/addon/flow-scanner.js
@@ -524,7 +524,23 @@ class FlowScanner {
       console.log("Flow status:", flow.status);
 
       // Always re-read localStorage for the latest state before building ruleConfig
-      const stored = JSON.parse(localStorage.getItem("flowScannerRules") || "[]");
+      let storedRaw = localStorage.getItem("flowScannerRules");
+      let stored;
+      try {
+        stored = JSON.parse(storedRaw || "[]");
+      } catch (e) {
+        console.warn("Failed to parse flowScannerRules, resetting", e);
+        stored = [];
+      }
+
+      if (!Array.isArray(stored)) {
+        if (stored && typeof stored === "object") {
+          stored = Object.entries(stored).map(([name, checked]) => ({name, checked: !!checked}));
+        } else {
+          stored = [];
+        }
+      }
+
       const selected = stored.filter(c => c.checked).map(c => c.name);
       let ruleConfig;
       try {


### PR DESCRIPTION
## Summary
- handle legacy object format for flow scanner rule configuration
- improve robustness when parsing stored rule preferences

## Testing
- `npm run eslint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_685d94ddea808331be3471c6ae013949